### PR TITLE
Style the landing page bg image

### DIFF
--- a/src/assets/scss/_coming_soon.scss
+++ b/src/assets/scss/_coming_soon.scss
@@ -1,14 +1,14 @@
 html {
-  background: url(../img/bg.jpeg) no-repeat center center fixed;
-  -webkit-background-size: cover;
-  -moz-background-size: cover;
-  -o-background-size: cover;
-  background-size: cover;
 }
 body {
   background: transparent !important;
 }
 .coming-soon {
+  background: url(../img/bg.jpeg) no-repeat center center fixed;
+  -webkit-background-size: cover;
+  -moz-background-size: cover;
+  -o-background-size: cover;
+  background-size: cover;
   font-family: 'Roboto Slab', serif;
   color: white;
   font-size: 1.4rem;


### PR DESCRIPTION
# What changes have you made
change the landing page background image style not to appear in the whole html page. Before every page contained the same image.

![screenshot from 2018-03-17 15-40-13](https://user-images.githubusercontent.com/19210094/37555535-a03bd168-29f9-11e8-867b-d9599e87eccd.png)
with the background as it was, the next container section is not visible.
![screenshot from 2018-03-17 15-45-22](https://user-images.githubusercontent.com/19210094/37555559-4009e888-29fa-11e8-84af-b94871b82f3e.png)
But with the changes one can easily scroll down the page and notice various sections of the website.


