### PR TITLE
make the coming_soon bg image to appear only on the coming_so…

### DIFF
--- a/src/assets/scss/_coming_soon.scss
+++ b/src/assets/scss/_coming_soon.scss
@@ -1,14 +1,14 @@
 html {
-  background: url(../img/bg.jpeg) no-repeat center center fixed;
-  -webkit-background-size: cover;
-  -moz-background-size: cover;
-  -o-background-size: cover;
-  background-size: cover;
 }
 body {
   background: transparent !important;
 }
 .coming-soon {
+  background: url(../img/bg.jpeg) no-repeat center center fixed;
+  -webkit-background-size: cover;
+  -moz-background-size: cover;
+  -o-background-size: cover;
+  background-size: cover;
   font-family: 'Roboto Slab', serif;
   color: white;
   font-size: 1.4rem;


### PR DESCRIPTION
…on section

# What changes have you made
  - change coming_soon background image to appear only on the coming_soon section

# Screenshots of the changes
## Desktop view
 -Before
![peek 2018-03-19 17-24](https://user-images.githubusercontent.com/19210094/37601259-a1d46b28-2b9a-11e8-81d6-2ae27dda694d.gif)

 -Now
![screen shot 2018-03-19 at 17 14 36-fullpage](https://user-images.githubusercontent.com/19210094/37600738-3b4cebf6-2b99-11e8-8ce1-959a4100691d.png)


## Mobile View
 -Now
![peek 2018-03-19 17-32](https://user-images.githubusercontent.com/19210094/37602050-9baa105c-2b9c-11e8-80f4-60498346589c.gif)

## GIFs
If some functionality changed or is introduced, attach a gif showing the changes or new feature

-Mobile
-Now

-Before
![peek 2018-03-19 17-45](https://user-images.githubusercontent.com/19210094/37602489-7f480f4e-2b9d-11e8-919b-80ebd0e91846.gif)


# Checks
  - [x] my code is well formated
  - [x] I only checked in the required files

# Request for a review
Remember to request for a review from team member
