### PR TITLE
fix team page overlapping bug

### DIFF
--- a/src/pages/team.html
+++ b/src/pages/team.html
@@ -6,7 +6,7 @@ pagetitle: Team Members | Podii
   <p class="description">Our team consists of Techies who are passionate and like-minded. We were brought together by a common interest and love for technology. We love and believe in what we do. Our key values consist of, creativity, integrity and collaboration</p>
   <div class="grid-x grid-padding-x team-wrap" data-equalizer data-equalize-on="medium" data-equalize-by-row="true">
     {{#each team}}
-    <div class="cell medium-4 member-details" data-equalizer-watch >
+    <div class="cell medium-4 member-details">
       <div class="callout">
         <div>
           <img class="circular" src="{{root}}assets/img/team/{{this.image}}" alt="picture of {{this.name}}"/><br>


### PR DESCRIPTION
# What changes have you made
  - modify div white space

# Screenshots of the changes

## Desktop view
 - Before

![preteam](https://user-images.githubusercontent.com/17137356/40383546-d3b3ddf8-5e09-11e8-9253-a107a0e4a1f1.gif)


 - After

![team](https://user-images.githubusercontent.com/17137356/40383999-f81cd86a-5e0a-11e8-8fce-24f94b89c06a.gif)



# Checks
  - [x] my code is well formated
  - [x] I only checked in the required files


